### PR TITLE
POOL_PATH default

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -21,7 +21,7 @@ fi
 # Initialize Variables
 #
 cron=""
-POOL_PATH="/mnt/v1"
+POOL_PATH=""
 APPS_PATH="apps"
 BACKUP_PATH="backup/apps"
 FILES_PATH="files"


### PR DESCRIPTION
Setting this when initialising variables will prevent the default from being set up if POOL_PATH is not defined in backup-config.